### PR TITLE
Reset results vars when nothing found

### DIFF
--- a/Classes/ViewHelpers/Data/FromSolrViewHelper.php
+++ b/Classes/ViewHelpers/Data/FromSolrViewHelper.php
@@ -130,6 +130,16 @@ class FromSolrViewHelper extends AbstractViewHelper
                 }
                 $templateVariableContainer->add('documents', $results);
             }
+        } else {
+            if ($templateVariableContainer->exists('numFound')) {
+                $templateVariableContainer->remove('numFound');
+            }
+            $templateVariableContainer->add('numFound', 0);
+
+            if ($templateVariableContainer->exists('documents')) {
+                $templateVariableContainer->remove('documents');
+            }
+            $templateVariableContainer->add('documents', NULL);
         }
 
         return $renderChildrenClosure();


### PR DESCRIPTION
With multiple runs of this ViewHelper and no results in run > 1 the results from t he first run were still valid. This commit resets the vars.