### PR TITLE
[FEATURE] Add Elasticsearch logging for search queries

### DIFF
--- a/Classes/Services/ElasticsearchLogService.php
+++ b/Classes/Services/ElasticsearchLogService.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace Slub\SlubFindExtend\Services;
+
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Sends search query logs to an Elasticsearch index.
+ */
+class ElasticsearchLogService
+{
+    private const PORTAL = 'slub-katalog';
+
+    private const INDEX_PREFIX = 'catalog-search-queries';
+
+    private const MIN_TIMEOUT_SECONDS = 0.3;
+
+    private const MAX_TIMEOUT_SECONDS = 0.5;
+
+    /**
+     * @var array<string, string>
+     */
+    private const QUERY_FIELD_MAP = [
+        'default' => 'all',
+        'author' => 'person_institution',
+        'author2' => 'person_institution',
+        'author_corporate' => 'person_institution',
+        'title' => 'title',
+        'topic' => 'subject_keyword',
+        'barcode' => 'barcode',
+        'ident' => 'identifier',
+        'isbn' => 'identifier',
+        'issn' => 'identifier',
+        'ismn' => 'identifier',
+        'doi' => 'identifier',
+        'ppn' => 'identifier',
+        'oclc' => 'identifier',
+        'rsn' => 'identifier',
+        'rvk' => 'rvk',
+        'rvk_facet' => 'rvk',
+        'signatur' => 'shelfmark',
+        'shelfmark' => 'shelfmark',
+        'imprint' => 'publisher_place',
+        'publisher' => 'publisher_place',
+        'publishplace' => 'publisher_place',
+        'series2' => 'series',
+        'series' => 'series',
+        'provenance' => 'provenance',
+    ];
+
+    protected string $elasticsearchUrl;
+
+    protected float $timeout;
+
+    protected string $username;
+
+    protected string $password;
+
+    protected bool $verifySsl;
+
+    public function __construct(string $elasticsearchUrl = '', string $indexName = 'find-search-log', float $timeout = 0.4)
+    {
+        $extensionConfiguration = (array)($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['slub_find_extend'] ?? []);
+
+        $this->elasticsearchUrl = rtrim($elasticsearchUrl ?: ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['slub_find_extend']['elasticsearchLogUrl'] ?? 'http://localhost:9200'), '/');
+
+        $configuredTimeout = $timeout > 0
+            ? $timeout
+            : (float)($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['slub_find_extend']['elasticsearchLogTimeout'] ?? 0.4);
+
+        // Keep the logging timeout short so the search request is not delayed.
+        $this->timeout = max(self::MIN_TIMEOUT_SECONDS, min(self::MAX_TIMEOUT_SECONDS, $configuredTimeout));
+
+        $this->username = trim((string)($extensionConfiguration['elasticsearchLogUsername'] ?? ''));
+        $this->password = (string)($extensionConfiguration['elasticsearchLogPassword'] ?? '');
+        $this->verifySsl = (bool)($extensionConfiguration['elasticsearchLogVerifySsl'] ?? true);
+    }
+
+    /**
+     * Logs a search event to Elasticsearch.
+     *
+     * @param array<string, mixed> $query             Parsed query arguments (typically tx_find_find[q]).
+     * @param int                  $numFound          Total result count.
+     * @param array<string, mixed> $requestArguments  Full tx_find_find request arguments.
+     * @param int|null             $responseTimeMs    Solr response time in milliseconds.
+     */
+    public function logSearch(array $query, int $numFound, array $requestArguments = [], ?int $responseTimeMs = null): void
+    {
+        $document = $this->buildDocument($query, $numFound, $requestArguments, $responseTimeMs);
+
+        $indexName = self::INDEX_PREFIX . '-' . date('Y.m');
+
+        $url = sprintf('%s/%s/_doc', $this->elasticsearchUrl, $indexName);
+
+        try {
+            /** @var RequestFactory $requestFactory */
+            $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+            $requestOptions = [
+                'headers' => ['Content-Type' => 'application/json'],
+                'body'    => json_encode($document, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'timeout' => $this->timeout,
+                'verify'  => $this->verifySsl,
+            ];
+
+            if ($this->username !== '' && $this->password !== '') {
+                $requestOptions['auth'] = [$this->username, $this->password];
+            }
+
+            $requestFactory->request(
+                $url,
+                'POST',
+                $requestOptions
+            );
+        } catch (\Throwable $e) {
+
+            // Logging-Fehler darf die Suchanfrage nicht unterbrechen.
+            $logger = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Log\LogManager::class)->getLogger(__CLASS__);
+            $logger->warning('Elasticsearch search log failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $requestArguments
+     * @return array<string, mixed>
+     */
+    private function buildDocument(array $query, int $numFound, array $requestArguments, ?int $responseTimeMs): array
+    {
+        $queryRows = $this->extractQueryRows($query);
+        $isSimpleAllSearch = count($queryRows) === 1 && ($queryRows[0]['field'] ?? null) === 'all';
+        $selectedFacets = $this->extractSelectedFacets($requestArguments);
+
+        $primaryQuery = $isSimpleAllSearch ? $queryRows[0]['query'] : null;
+        $normalizedPrimaryQuery = $isSimpleAllSearch ? $queryRows[0]['normalized_query'] : null;
+
+        $page = $this->toNullableInt($requestArguments['page'] ?? null);
+        $pageSize = $this->toNullableInt($requestArguments['count'] ?? null);
+
+        return [
+            '@timestamp' => date('c'),
+            'portal' => self::PORTAL,
+            'environment' => $this->resolveEnvironment(),
+            'search_type' => $isSimpleAllSearch ? 'simple' : 'advanced',
+            'is_all_search' => $isSimpleAllSearch,
+            'primary_query' => $primaryQuery,
+            'normalized_primary_query' => $normalizedPrimaryQuery,
+            'primary_scope' => $isSimpleAllSearch ? 'all' : null,
+            'fields' => $queryRows,
+            'field_count' => count($queryRows),
+            'used_fields' => array_values(array_unique(array_column($queryRows, 'field'))),
+            'selected_facets' => $selectedFacets,
+            'selected_facet_count' => count($selectedFacets),
+            'selected_facet_ids' => array_values(array_unique(array_column($selectedFacets, 'facet'))),
+            'result_count' => $numFound,
+            'zero_results' => $numFound === 0,
+            'page' => $page,
+            'page_size' => $pageSize,
+            'response_time_ms' => $responseTimeMs,
+            'intent' => null,
+            'intent_confidence' => null,
+            'search_strategy' => null,
+            'metadata' => [
+                'request_id' => $this->resolveRequestId(),
+                'session_hash' => $this->resolveSessionHash(),
+                'language' => $this->resolveLanguage(),
+                'device' => $this->resolveDevice(),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @return array<int, array<string, int|string|null>>
+     */
+    private function extractQueryRows(array $query): array
+    {
+        $rows = [];
+        $position = 1;
+
+        foreach ($query as $rawField => $rawValue) {
+            $field = $this->mapField($rawField);
+            if ($field === null) {
+                continue;
+            }
+
+            $values = is_array($rawValue) ? $rawValue : [$rawValue];
+            foreach ($values as $value) {
+                $queryValue = $this->sanitizeQuery($value);
+                if ($queryValue === null) {
+                    continue;
+                }
+
+                $rows[] = [
+                    'field' => $field,
+                    'query' => $queryValue,
+                    'normalized_query' => $this->normalizeQuery($queryValue),
+                    'position' => $position,
+                    'operator' => $position === 1 ? null : 'AND',
+                ];
+                $position++;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $requestArguments
+     * @return array<int, array<string, string>>
+     */
+    private function extractSelectedFacets(array $requestArguments): array
+    {
+        $facets = [];
+        $rawFacets = $requestArguments['facet'] ?? null;
+
+        if (!is_array($rawFacets)) {
+            return $facets;
+        }
+
+        foreach ($rawFacets as $facetId => $facetSelection) {
+            if (!is_array($facetSelection)) {
+                continue;
+            }
+
+            $facetId = trim((string)$facetId);
+            if ($facetId === '') {
+                continue;
+            }
+
+            foreach ($facetSelection as $term => $status) {
+                $term = trim(urldecode((string)$term));
+                if ($term === '') {
+                    continue;
+                }
+
+                $status = trim((string)$status);
+                if ($status === '') {
+                    $status = '1';
+                }
+
+                $facets[] = [
+                    'facet' => $facetId,
+                    'term' => $term,
+                    'status' => $status,
+                ];
+            }
+        }
+
+        return $facets;
+    }
+
+    private function mapField(string $field): ?string
+    {
+        $normalized = strtolower(trim($field));
+        return self::QUERY_FIELD_MAP[$normalized] ?? null;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function sanitizeQuery($value): ?string
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $query = trim((string)$value);
+        return $query === '' ? null : $query;
+    }
+
+    private function normalizeQuery(string $query): string
+    {
+        $query = trim($query);
+        $query = preg_replace('/\s+/', ' ', $query) ?? $query;
+        return mb_strtolower($query, 'UTF-8');
+    }
+
+    private function resolveEnvironment(): string
+    {
+        $context = (string)(getenv('TYPO3_CONTEXT') ?: ($_SERVER['TYPO3_CONTEXT'] ?? ''));
+        if ($context === '') {
+            $context = (string)($GLOBALS['TYPO3_CONF_VARS']['SYS']['applicationContext'] ?? '');
+        }
+
+        $context = trim($context);
+        return $context !== '' ? $context : 'Production';
+    }
+
+    private function resolveRequestId(): ?string
+    {
+        $server = $_SERVER;
+
+        $requestId = $server['HTTP_X_REQUEST_ID']
+            ?? $server['HTTP_X_CORRELATION_ID']
+            ?? null;
+
+        $requestId = is_scalar($requestId) ? trim((string)$requestId) : '';
+        return $requestId !== '' ? $requestId : null;
+    }
+
+    private function resolveSessionHash(): ?string
+    {
+        $cookieName = session_name();
+        if ($cookieName === '') {
+            return null;
+        }
+
+        $sessionId = $_COOKIE[$cookieName] ?? null;
+        if (!is_string($sessionId) || trim($sessionId) === '') {
+            return null;
+        }
+
+        $encryptionKey = (string)($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] ?? '');
+        if ($encryptionKey === '') {
+            return null;
+        }
+
+        return hash('sha256', $encryptionKey . '|' . $sessionId);
+    }
+
+    private function resolveLanguage(): ?string
+    {
+        $language = (string)($GLOBALS['TSFE']->config['config']['language'] ?? '');
+        $language = strtolower(trim($language));
+
+        if ($language === '') {
+            return null;
+        }
+
+        if (str_starts_with($language, 'de')) {
+            return 'de';
+        }
+
+        if (str_starts_with($language, 'en')) {
+            return 'en';
+        }
+
+        return null;
+    }
+
+    private function resolveDevice(): ?string
+    {
+        $userAgent = strtolower((string)($_SERVER['HTTP_USER_AGENT'] ?? ''));
+        if ($userAgent === '') {
+            return null;
+        }
+
+        if (str_contains($userAgent, 'tablet') || str_contains($userAgent, 'ipad')) {
+            return 'tablet';
+        }
+
+        if (str_contains($userAgent, 'mobile') || str_contains($userAgent, 'android') || str_contains($userAgent, 'iphone')) {
+            return 'mobile';
+        }
+
+        return 'desktop';
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function toNullableInt($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (!is_scalar($value) || !is_numeric((string)$value)) {
+            return null;
+        }
+
+        return (int)$value;
+    }
+}

--- a/Classes/Slots/LogSearchQuery.php
+++ b/Classes/Slots/LogSearchQuery.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Slub\SlubFindExtend\Slots;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Slub\SlubFindExtend\Services\ElasticsearchLogService;
+use Solarium\QueryType\Select\Result\Result;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+
+/**
+ * Slot: Logs each find search request (query + result count) to Elasticsearch.
+ *
+ * Hooks into: Subugoe\Find\Controller\SearchController::indexActionBeforeRender
+ */
+class LogSearchQuery
+{
+    protected array $settings = [];
+
+    protected ConfigurationManagerInterface $configurationManager;
+
+    public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
+    {
+        $this->configurationManager = $configurationManager;
+        $this->settings = $this->configurationManager->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS
+        );
+    }
+
+    /**
+     * Called via SignalSlot after Solr executed the search query.
+     *
+     * @param Result|null $resultSet  Passed by reference from SolrServiceProvider::getDefaultQuery()
+     */
+    public function index(&$resultSet): void
+    {
+        // No result set means an error occurred – nothing useful to log.
+        if (!$resultSet instanceof Result) {
+            return;
+        }
+
+        $loggerSettings = is_array($this->settings['elasticsearchLog'] ?? null)
+            ? $this->settings['elasticsearchLog']
+            : [];
+
+        $enabled = (int)($loggerSettings['enabled'] ?? ($this->settings['elasticsearchLogEnabled'] ?? 0)) === 1;
+        if (!$enabled) {
+            return;
+        }
+
+        $numFound = (int) $resultSet->getNumFound();
+
+        // Extract query arguments from current request.
+        $requestArguments = GeneralUtility::_GPmerged('tx_find_find');
+        $query = is_array($requestArguments['q'] ?? null) ? $requestArguments['q'] : ['default' => (string) ($requestArguments['q'] ?? '')];
+
+        $elasticsearchUrl = (string)($loggerSettings['url'] ?? ($this->settings['elasticsearchLogUrl'] ?? ''));
+        if ($elasticsearchUrl === '') {
+            return;
+        }
+        
+        $indexName = (string)($loggerSettings['index'] ?? ($this->settings['elasticsearchLogIndex'] ?? 'find-search-log'));
+        $timeout = (float)($loggerSettings['timeout'] ?? 0.4);
+        if ($timeout > 1) {
+            $timeout = $timeout / 1000;
+        }
+        $timeout = max(0.3, min(0.5, $timeout));
+
+        $responseTimeMs = $this->resolveResponseTimeMs($resultSet);
+
+        $service = GeneralUtility::makeInstance(ElasticsearchLogService::class, $elasticsearchUrl, $indexName, $timeout);
+        $service->logSearch($query, $numFound, $requestArguments, $responseTimeMs);
+    }
+
+    private function resolveResponseTimeMs(Result $resultSet): ?int
+    {
+        if (method_exists($resultSet, 'getResponse')) {
+            $response = $resultSet->getResponse();
+            if (is_object($response) && method_exists($response, 'getData')) {
+                $data = $response->getData();
+                if (is_array($data)) {
+                    $qTime = $data['responseHeader']['QTime'] ?? null;
+                    if (is_numeric($qTime)) {
+                        return (int)round((float)$qTime);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/Configuration/TypoScript/ElasticsearchLogger/constants.typoscript
+++ b/Configuration/TypoScript/ElasticsearchLogger/constants.typoscript
@@ -1,0 +1,5 @@
+plugin.tx_find.settings.elasticsearchLogEnabled = 0
+plugin.tx_find.settings.elasticsearchLogUrl = https://elasticsearch.example.org:9200
+plugin.tx_find.settings.elasticsearchLogIndex = slub-find-search-log
+plugin.tx_find.settings.elasticsearchLogSite = katalog
+plugin.tx_find.settings.elasticsearchLogTimeout = 0.4

--- a/Configuration/TypoScript/ElasticsearchLogger/setup.typoscript
+++ b/Configuration/TypoScript/ElasticsearchLogger/setup.typoscript
@@ -1,0 +1,10 @@
+plugin.tx_find.settings {
+  elasticsearchLog {
+    enabled = {$plugin.tx_find.settings.elasticsearchLogEnabled}
+    url = {$plugin.tx_find.settings.elasticsearchLogUrl}
+    index = {$plugin.tx_find.settings.elasticsearchLogIndex}
+    site = {$plugin.tx_find.settings.elasticsearchLogSite}
+    timeout = {$plugin.tx_find.settings.elasticsearchLogTimeout}
+  }
+  omitHeader = false
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -28,6 +28,16 @@ $signalSlotDispatcher->connect(
 );
 
 // Hook into \Subugoe\Find\Controller
+// Log search queries to Elasticsearch
+$signalSlotDispatcher->connect(
+    'Subugoe\Find\Controller\SearchController',
+    'indexActionBeforeRender',
+    'Slub\SlubFindExtend\Slots\LogSearchQuery',
+    'index',
+    false
+);
+
+// Hook into \Subugoe\Find\Controller
 $signalSlotDispatcher->connect(
     'Subugoe\Find\Controller\SearchController',
     'indexActionBeforeRender',

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,0 +1,9 @@
+<?php
+
+defined('TYPO3_MODE') or die();
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'slub_find_extend',
+    'Configuration/TypoScript/ElasticsearchLogger',
+    'SLUB Find Extend: Elasticsearch Logger'
+);


### PR DESCRIPTION
Implement logging of search queries to Elasticsearch by connecting to the SearchController's indexActionBeforeRender signal. This includes the creation of ElasticsearchLogService and LogSearchQuery classes to handle the logging functionality.